### PR TITLE
Introduce no_std compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ version = "1.0.2"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/sunshowers-code/debug-ignore"
 documentation = "https://docs.rs/debug-ignore"
+keywords = ["no-std"]
 
 [dependencies]
 serde = { version = "1", optional = true, default-features = false, features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,9 @@
 //! * [`derivative`](https://crates.io/crates/derivative) has greater control over the behavior of
 //!   `Debug` impls, at the cost of a compile-time proc-macro dependency.
 
-use std::{
+#![no_std]
+
+use core::{
     fmt,
     ops::{Deref, DerefMut},
     str::FromStr,


### PR DESCRIPTION
This crate is currently incompatibility with microcontrollers, as it isn't `no_std`.

It doesn't use a single feature of `std` though, so this PR introduces `no_std` compatibility.